### PR TITLE
add rv integration in nuke

### DIFF
--- a/openpype/hosts/nuke/api/pipeline.py
+++ b/openpype/hosts/nuke/api/pipeline.py
@@ -23,7 +23,7 @@ from openpype.pipeline import (
 )
 from openpype.pipeline.workfile import BuildWorkfile
 from openpype.tools.utils import host_tools
-
+from openpype.lib.applications import ApplicationManager
 from .command import viewer_update_and_undo_stop
 from .lib import (
     Context,
@@ -319,6 +319,8 @@ def _install_menu():
     # adding shortcuts
     add_shortcuts_from_presets()
 
+    # adding rv
+    add_rv_from_presets()
 
 def change_context_label():
     menubar = nuke.menu("Nuke")
@@ -343,6 +345,53 @@ def change_context_label():
 
     log.info("Task label changed from `{}` to `{}`".format(
         Context.context_label, label))
+
+
+def add_rv_from_presets():
+    rv_settings = get_current_project_settings()["openrv"]['openrv_nuke_integration']
+
+    if not rv_settings['rvnuke_enabled']:
+        return
+
+    if 'rvnuke_content_paths' not in rv_settings:
+        return
+
+    for rv_nuke_path in rv_settings['rvnuke_content_paths']:
+        if os.path.exists(rv_nuke_path):
+            nuke.pluginAddPath(rv_nuke_path)
+            log.info("RV Nuke path added: {}".format(rv_nuke_path))
+        else:
+            log.warning("RV Nuke path not found: {}".format(rv_nuke_path))
+
+    app_manager = ApplicationManager()
+    openrv_app = app_manager.find_latest_available_variant_for_group("openrv")
+    rv_exec_path = str(openrv_app.find_executable())
+
+    if not rv_exec_path:
+        return
+    try:
+        import rvNuke
+        rv_pref_panel = rvNuke.RvPreferencesPanel()
+        rv_pref_panel.rvPrefs.prefs["rvExecPath"] = rv_exec_path
+        rv_pref_panel.rvPrefs.saveToDisk()
+    except ImportError:
+        log.warning("rvNuke not found")
+
+    nuke.addOnCreate(add_rv_shortcut, nodeClass="Root")
+    return
+
+
+def add_rv_shortcut():
+    rv_global_settings = get_current_project_settings()["openrv"]
+    rv_settings = rv_global_settings['openrv_nuke_integration']
+    if rv_settings['rvnuke_open_in_rv_shortcut']:
+        menubar = nuke.menu("Nuke")
+        menu_item = menubar.findItem("RV/View in RV")
+        menu_item.setShortcut("Alt+v")
+        menu_item.setShortcut(rv_settings['rvnuke_open_in_rv_shortcut'])
+        log.info("Adding Shortcut `{}` to `{}`".format(
+            'Open in RV',
+            rv_settings['rvnuke_open_in_rv_shortcut']))
 
 
 def add_shortcuts_from_presets():

--- a/openpype/settings/defaults/project_settings/openrv.json
+++ b/openpype/settings/defaults/project_settings/openrv.json
@@ -8,5 +8,10 @@
             "enabled": true,
             "rules": {}
         }
+    },
+        "openrv_nuke_integration": {
+        "rvnuke_enabled": false,
+        "rvnuke_content_paths" : [],
+        "rvnuke_open_in_rv_shortcut" : "Alt+v"
     }
 }

--- a/openpype/settings/entities/schemas/projects_schema/schema_project_openrv.json
+++ b/openpype/settings/entities/schemas/projects_schema/schema_project_openrv.json
@@ -21,6 +21,33 @@
                     "name": "schema_imageio_file_rules"
                 }
             ]
+        },
+        {
+            "key": "openrv_nuke_integration",
+            "type": "dict",
+            "label": "Nuke integration",
+            "collapsible": true,
+            "is_group": true,
+            "children": [
+                {
+                    "type": "boolean",
+                    "key": "rvnuke_enabled",
+                    "label": "Enable RV Nuke integration"
+                },
+
+                {
+                    "type": "text",
+                    "key": "rvnuke_open_in_rv_shortcut",
+                    "label": "Open In Rv Shortcut"
+                },
+                {
+                    "type": "path",
+                    "key": "rvnuke_content_paths",
+                    "label": "RV Nuke Content Paths",
+                    "multiplatform": false,
+                    "multipath": true
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
**Works with OpenPype 3.15.5, require an update to work with 3.15.10**
## Changelog Description
Added OpenRV Nuke Integration feature, allowing users to launch OpenRV/RV within Nuke. This update enhances the workflow by providing seamless integration between OpenRV/RV and Nuke. Users can now easily switch between applications, giving supervisors the possibility to conduct faster reviews directly from Write/Read Nodes, Checkpoint in Nuke.

Also it give you access to all the commands provided by rvNuke module, which are : 
- **Start RV**: Launches RV when selected from the toolbar.
- **Create Checkpoint**: Creates a checkpoint in RV for the current Nuke script.
- **View in RV**: Opens selected Read/Write nodes in RV for viewing.
- **Render to RV**: Sends the current Nuke script to RV for rendering.
- **Project Settings ...**: Opens the Nuke project settings panel.
- **Preferences ...**: Opens the RV preferences panel, enabling users to customize RV's exec and arguments

For more information, please refer to the [Pull Request #4839](https://github.com/ynput/OpenPype/pull/4839).

## Additional Info
Regarding the Pull Request, the OpenRV Nuke Integration involves modifications to several files from the [Pull Request #4839](https://github.com/ynput/OpenPype/pull/4839). The following files have been modified for the OpenRV Nuke Integration:

- `openpype/hosts/nuke/api/pipeline.py`
- `openpype/settings/defaults/project_settings/openrv.json`
- `openpype/settings/entities/schemas/projects_schema/schema_project_openrv.json`


## Testing Notes:
To launch RV in Nuke, follow these steps:

1. Open the Project Settings in OpenPype.
2. Navigate to OpenRv > Nuke Integration.
3. Add the path to the 'rvnuke' python module. This plugin is automatically built with OpenRV/RV.
4. Enable the OpenRV integration in Nuke.

Once these steps are completed, users will be able to seamlessly launch OpenRV/RV within Nuke and leverage its functionality for an enhanced workflow and collaboration experience.

Additionally, users can launch RV directly from Read or Write Nodes in Nuke using one of the following methods:
- **Custom Shortcut**: In the OpenRv > Nuke Integration settings, specify a custom shortcut within Nuke to launch RV with a single key combination.
- **Default Shortcut**: By default, pressing Alt+V while a Read or Write Node is selected in Nuke will launch RV for quick and convenient review of the associated footage.